### PR TITLE
Update to Dragula 3.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ git submodule update
 
 #Changelog
 
+## 1.0.3
+  * Update Dragula to version 3.0.7
+
 ## 1.0.2
 	* Update git url to not 404
 
-## 1.0.1 
+## 1.0.1
 	* Initial release to Atmosphere
 
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: 'Dragula - Drag and drop so simple it hurts, packaged for meteor',
   name: 'ahref:dragula',
-  version: '1.0.3',
+  version: '1.1.0',
   git:'https://github.com/rfox90/meteor-dragula'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: 'Dragula - Drag and drop so simple it hurts, packaged for meteor',
   name: 'ahref:dragula',
-  version: '1.1.0',
+  version: '1.0.3',
   git:'https://github.com/rfox90/meteor-dragula'
 });
 


### PR DESCRIPTION
Great package!

There are some neat things in 3.0.7 including the change to using `mousemove` instead of dealing with a `delay` for touch devices.

Bumped this package up a minor version, but would be happy to bump it up more if we're concerned about breaking changes.
